### PR TITLE
Use Version class for version check

### DIFF
--- a/JWLMerge/Helpers/VersionDetection.cs
+++ b/JWLMerge/Helpers/VersionDetection.cs
@@ -8,7 +8,7 @@
 
     internal static class VersionDetection
     {
-        public static string GetLatestReleaseVersion(string latestReleaseUrl)
+        public static Version GetLatestReleaseVersion(string latestReleaseUrl)
         {
             string version = null;
 
@@ -37,13 +37,13 @@
                 Log.Logger.Error(ex, "Getting latest release version");
             }
 
-            return version;
+            return !string.IsNullOrWhiteSpace(version) ? new Version(version) : null;
         }
 
-        public static string GetCurrentVersion()
+        public static Version GetCurrentVersion()
         {
             var ver = Assembly.GetExecutingAssembly().GetName().Version;
-            return $"{ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision}";
+            return new Version($"{ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision}");
         }
     }
 }

--- a/JWLMerge/ViewModel/MainViewModel.cs
+++ b/JWLMerge/ViewModel/MainViewModel.cs
@@ -339,14 +339,11 @@ namespace JWLMerge.ViewModel
                 Task.Delay(2000).ContinueWith(_ =>
                 {
                     var latestVersion = VersionDetection.GetLatestReleaseVersion(LatestReleaseUrl);
-                    if (latestVersion != null)
+                    if (latestVersion != null && VersionDetection.GetCurrentVersion().CompareTo(latestVersion) < 0)
                     {
-                        if (latestVersion != VersionDetection.GetCurrentVersion())
-                        {
-                            // there is a new version....
-                            IsNewVersionAvailable = true;
-                            RaisePropertyChanged(nameof(IsNewVersionAvailable));
-                        }
+                        // there is a new version....
+                        IsNewVersionAvailable = true;
+                        RaisePropertyChanged(nameof(IsNewVersionAvailable));
                     }
                 });
             }


### PR DESCRIPTION
Thanks for sending a pull request! Please review the [guidelines for contributing](CONTRIBUTING.md), then fill out the blanks below.

What does this implement/fix? Explain your changes
--------------------------------------------------
The version currently in the repo is 1.0.0.19 while the released version is 1.0.0.18. Because the version check is only checking for inequality the locally built app is incorrectly giving a "update available" message. To fix this the `Version` class was leveraged for doing version comparisons.

Does this close any currently open issues?
------------------------------------------
No.

Any other comments?
-------------------
Thanks for reviewing.
